### PR TITLE
Use branch friendly names for creation of PR

### DIFF
--- a/RepositoryProcessor.cs
+++ b/RepositoryProcessor.cs
@@ -169,7 +169,7 @@ namespace MassPullRequest
             var repoName = urlParts.Last();
             var owner = urlParts[urlParts.Count - 2];
 
-            var pr = new NewPullRequest(pullRequestTitle, _changesBranch.Reference.CanonicalName, _baseBranch.Reference.CanonicalName);
+            var pr = new NewPullRequest(pullRequestTitle, _changesBranch.FriendlyName, _baseBranch.FriendlyName);
 
             client.PullRequest.Create(owner, repoName, pr).Wait();
         }


### PR DESCRIPTION
Fixes an issue where Github was unable to actually merge PRs generated by this tool. Just requires using the short branch name rather than the full `/refs/heads/whatever`.